### PR TITLE
Pin Janus version in Habitat plan

### DIFF
--- a/plans/janus-gateway/habitat/plan.sh
+++ b/plans/janus-gateway/habitat/plan.sh
@@ -69,7 +69,7 @@ do_download() {
   pushd $HAB_CACHE_SRC_PATH
 
   git-get meetecho/janus-gateway 3d0d248e9f8be4ed793c881513e7e87cb431d19e
-  git-get mozilla/janus-plugin-sfu
+  git-get mozilla/janus-plugin-sfu f24c41a0bfc795d53661178af692990d77670c42
 
   popd
 }


### PR DESCRIPTION
Seems like it's better to pin everything and update explicitly since we will sometimes want to update only upstream Janus.