### PR TITLE
Retain debug symbols in Janus binary

### DIFF
--- a/plans/janus-gateway/habitat/plan.sh
+++ b/plans/janus-gateway/habitat/plan.sh
@@ -74,6 +74,10 @@ do_download() {
   popd
 }
 
+do_strip() {
+    build_line "Conspicuously not stripping unneeded symbols from binaries and libraries, like Habitat would do by default"
+}
+
 do_build() {
   pushd $HAB_CACHE_SRC_PATH/meetecho/janus-gateway
 


### PR DESCRIPTION
Remarkably, Habitat strips them by default, which is sad news for our crash diagnosing efforts.