### PR TITLE
Bump hab base to Ubuntu 18.04

### DIFF
--- a/packer/hab-base/image.json
+++ b/packer/hab-base/image.json
@@ -14,9 +14,9 @@
     "security_group_id": "sg-37a2c751",
     "source_ami_filter": {
       "filters": {
-      "virtualization-type": "hvm",
-      "name": "ubuntu/images/*ubuntu-artful-17.10-amd64-server-*",
-      "root-device-type": "ebs"
+        "virtualization-type": "hvm",
+        "name": "ubuntu/images/*ubuntu-bionic-18.04-amd64-server-*",
+        "root-device-type": "ebs"
       },
       "owners": ["099720109477"],
       "most_recent": true


### PR DESCRIPTION
This should be an easy upgrade, since all of the "heavy lifting" on these boxes is inside Habitat.

As of the time of this writing, I applied this AMI to all of the dev cluster boxes; that's hab, ci, ret, and janus. I'm waiting to apply it to prod for when Greg is around and when we're willing to accept downtime (since Janus has no redundancy and no way to migrate users from one box to the next.)