### PR TITLE
Bump bastion base to Ubuntu 18.04, cycle TOTP secret

### DIFF
--- a/packer/bastion/image.json
+++ b/packer/bastion/image.json
@@ -14,9 +14,9 @@
     "security_group_id": "sg-37a2c751",
     "source_ami_filter": {
       "filters": {
-      "virtualization-type": "hvm",
-      "name": "ubuntu/images/*ubuntu-xenial-16.04-amd64-server-*",
-      "root-device-type": "ebs"
+        "virtualization-type": "hvm",
+        "name": "ubuntu/images/*ubuntu-bionic-18.04-amd64-server-*",
+        "root-device-type": "ebs"
       },
       "owners": ["099720109477"],
       "most_recent": true


### PR DESCRIPTION
I created and tested a new AMI from this with a new TOTP secret. I'm going to hold off upgrading instances to the new AMI until Monday when I can tell everyone the secret.