### PR TITLE
Support Janus over TCP

### DIFF
--- a/ansible/roles/janus/templates/janus-gateway.toml.j2
+++ b/ansible/roles/janus/templates/janus-gateway.toml.j2
@@ -10,6 +10,8 @@ rtp_port_range = "20000-60000"
 
 [nat]
 ice_ignore_list = "eth0:0"
+ice_lite = "true"
+ice_tcp = "true"
 
 [plugins.sfu]
 max_room_size = 16

--- a/terraform/modules/janus/main.tf
+++ b/terraform/modules/janus/main.tf
@@ -69,11 +69,19 @@ resource "aws_security_group" "janus" {
     security_groups = ["${data.terraform_remote_state.bastion.bastion_security_group_id}"]
   }
 
-  # Janus RTP
+  # Janus RTP-over-UDP
   ingress {
     from_port = "${var.janus_rtp_port_from}"
     to_port = "${var.janus_rtp_port_to}"
     protocol = "udp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Janus RTP-over-TCP
+  ingress {
+    from_port = "${var.janus_rtp_port_from}"
+    to_port = "${var.janus_rtp_port_to}"
+    protocol = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
 


### PR DESCRIPTION
This will let people use Hubs even in networks that don't permit UDP, which is cool.