### PR TITLE
Adjust logging for Janus

### DIFF
--- a/ansible/roles/janus/templates/janus-gateway.toml.j2
+++ b/ansible/roles/janus/templates/janus-gateway.toml.j2
@@ -3,7 +3,7 @@ server_name = "janus"
 admin_secret = "{{ janus_admin_secret }}"
 api_secret = ""
 log_to_syslog = "true"
-debug_level = 5
+debug_level = 4
 
 [media]
 rtp_port_range = "20000-60000"

--- a/terraform/modules/janus/main.tf
+++ b/terraform/modules/janus/main.tf
@@ -146,9 +146,8 @@ nat_1_1_mapping = "$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4
 admin_ip = "$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)"
 EOTOML
 
-# TODO this causes large janus CPU spike
-# sudo sed -i "s/#RateLimitBurst=1000/RateLimitBurst=5000/" /etc/systemd/journald.conf
-# sudo systemctl restart systemd-journald
+sudo sed -i "s/#RateLimitBurst=1000/RateLimitBurst=5000/" /etc/systemd/journald.conf
+sudo systemctl restart systemd-journald
 
 sudo /usr/bin/hab svc load mozillareality/janus-gateway --strategy ${var.janus_restart_strategy} --url https://bldr.habitat.sh --channel ${var.janus_channel}
 sudo /usr/bin/hab svc load mozillareality/dd-agent --strategy at-once --url https://bldr.habitat.sh --channel stable
@@ -199,9 +198,8 @@ nat_1_1_mapping = "$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4
 admin_ip = "$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)"
 EOTOML
 
-# TODO this causes large Janus CPU spike
-# sudo sed -i "s/#RateLimitBurst=1000/RateLimitBurst=5000/" /etc/systemd/journald.conf
-# sudo systemctl restart systemd-journald
+sudo sed -i "s/#RateLimitBurst=1000/RateLimitBurst=5000/" /etc/systemd/journald.conf
+sudo systemctl restart systemd-journald
 
 sudo /usr/bin/hab svc load mozillareality/janus-gateway --strategy at-once --url https://bldr.habitat.sh --channel unstable
 sudo /usr/bin/hab svc load mozillareality/dd-agent --strategy at-once --url https://bldr.habitat.sh --channel stable


### PR DESCRIPTION
Turn Janus down to INFO while simultaneously increasing the journald log limit back to a reasonable value.