### PR TITLE
Add Spoke origin to cors-proxy whitelist

### DIFF
--- a/workers/cors-proxy.js
+++ b/workers/cors-proxy.js
@@ -1,4 +1,4 @@
-const ALLOWED_ORIGINS = ["https://hubs.local:8080", "https://hubs.local:4000", "https://dev.reticulum.io", "https://smoke-dev.reticulum.io", "https://hubs.mozilla.com", "https://smoke-hubs.mozilla.com"];
+const ALLOWED_ORIGINS = ["https://hubs.local:8080", "https://hubs.local:9090", "https://hubs.local:4000", "https://dev.reticulum.io", "https://smoke-dev.reticulum.io", "https://hubs.mozilla.com", "https://smoke-hubs.mozilla.com"];
 const PROXY_HOST = "https://hubs-proxy.com"
 
 addEventListener("fetch", e => {


### PR DESCRIPTION
Spoke is currently using Farspark for all media when working in development. This PR adds `https://hubs.local:9090` as an allowed origin so that we can use the cors-proxy in development