### PR TITLE
Bump Janus 0.4.3->0.4.5

### DIFF
--- a/plans/janus-gateway/habitat/plan.sh
+++ b/plans/janus-gateway/habitat/plan.sh
@@ -2,7 +2,7 @@ pkg_name=janus-gateway
 pkg_origin=mozillareality
 pkg_maintainer="Mozilla Mixed Reality <mixreality@mozilla.com>"
 
-pkg_version="0.4.3"
+pkg_version="0.4.5"
 pkg_license=('GPLv3')
 pkg_description="Janus is an open source, general purpose, WebRTC gateway"
 pkg_upstream_url="https://janus.conf.meetecho.com/"
@@ -72,7 +72,7 @@ do_download() {
 
   pushd $HAB_CACHE_SRC_PATH
 
-  git-get meetecho/janus-gateway 3c5ad1b125f696a32c85420f31a24eec79b35028
+  git-get meetecho/janus-gateway v0.4.5
   git-get mozilla/janus-plugin-sfu 97be0ad45747d5c04f2e10a5b3e74cc997445d89
 
   popd


### PR DESCRIPTION
This is necessary to get fixes related to mDNS ICE candidates for Chrome. See:

- https://github.com/meetecho/janus-gateway/commit/0a5f379ad3bc521718cd0fb90e3008a09837baff
- https://groups.google.com/d/msg/discuss-webrtc/4Yggl6ZzqZk/yawz3VVLDgAJ
- https://groups.google.com/d/msg/discuss-webrtc/4Yggl6ZzqZk/GaGLSpRTDgAJ
- https://groups.google.com/d/msg/discuss-webrtc/4Yggl6ZzqZk/Hjd84-1UDgAJ

It also contains a few other interesting bugfixes, like https://github.com/meetecho/janus-gateway/pull/1356, although not obviously any ones that are super important to us.