### PR TITLE
More accurate columnization of moz-ec2 output

### DIFF
--- a/helpers.sh
+++ b/helpers.sh
@@ -40,7 +40,7 @@ function moz-ec2 {
       .PrivateIpAddress // "null",
       .PublicIpAddress // "null"
     ] | @tsv' <<< "$ALL")
-    echo "${OUTPUT}" | sort -k2,2 -k3,3 | column -t
+    echo "${OUTPUT}" | sort -k2,2 -k3,3 | column -t -s $'\t'
 }
 
 # moz-host env asg


### PR DESCRIPTION
Now it doesn't screw up the formatting when column contents have spaces (e.g. someone has made a host named "QEMU Image Builder") because it knows the difference between spaces and tabs.