### PR TITLE
Feature/april coturn update

### DIFF
--- a/ansible/roles/janus/templates/coturn.toml.j2
+++ b/ansible/roles/janus/templates/coturn.toml.j2
@@ -7,6 +7,7 @@ max_port = {{ coturn_max_port }}
 min_port = {{ coturn_min_port }}
 tls_listening_port = {{ coturn_tls_listening_port }}
 psql_userdb = "{{ coturn_psql_userdb }}"
+psql_schema = "coturn"
 use_auth_secret = "true"
 
 {% if coturn_listening_ip is defined %}

--- a/ansible/roles/janus/templates/coturn.toml.j2
+++ b/ansible/roles/janus/templates/coturn.toml.j2
@@ -3,6 +3,7 @@ realm = "{{ coturn_realm }}"
 no_udp = "{{ coturn_no_udp }}"
 no_tcp = "{{ coturn_no_tcp }}"
 no_dtls = "{{ coturn_no_dtls }}"
+no_tls = "{{ coturn_no_tls }}"
 max_port = {{ coturn_max_port }}
 min_port = {{ coturn_min_port }}
 tls_listening_port = {{ coturn_tls_listening_port }}

--- a/cloudformation/stack.yaml
+++ b/cloudformation/stack.yaml
@@ -430,7 +430,7 @@ Conditions:
   HasStreamingServers: !And [!Equals [!Ref StackOffline, "Online"], !Not [!Equals [!Ref StreamInstanceCount, 0]]]
   AppIsNoPlacement: !Equals [!Ref AppPlacementGroupStrategy, none]
   AppIsClusterPlacement: !Equals [!Ref AppPlacementGroupStrategy, cluster]
-  HasEmailSubdomain: !Equals [!Ref EmailSubdomain, ""]
+  HasEmailSubdomain: !Not [!Equals [!Ref EmailSubdomain, ""]]
   CreateDiskEncryptionKey: !Equals [!Ref NewCMKForDiskEncryption, "Yes - Create a new CMK"]
   SubnetChoiceA: !Equals [!Ref SubnetAZs, "Use zone a and b"]
   SubnetChoiceB: !Equals [!Ref SubnetAZs, "Use zone b and c"]

--- a/cloudformation/stack.yaml
+++ b/cloudformation/stack.yaml
@@ -2481,11 +2481,19 @@ Resources:
           FromPort: !FindInMap [ServicesMeta, RetTurnExternal, Port]
           ToPort: !FindInMap [ServicesMeta, RetTurnExternal, Port]
           CidrIp: !If [HasInboundCidrOverride, !Ref InboundCidrOverride, "0.0.0.0/0"]
+        - IpProtocol: udp
+          FromPort: !FindInMap [ServicesMeta, RetTurnExternal, Port]
+          ToPort: !FindInMap [ServicesMeta, RetTurnExternal, Port]
+          CidrIp: !If [HasInboundCidrOverride, !Ref InboundCidrOverride, "0.0.0.0/0"]
         - IpProtocol: tcp
           FromPort: !FindInMap [ServicesMeta, JanusExternal, Port]
           ToPort: !FindInMap [ServicesMeta, JanusExternal, Port]
           CidrIp: !If [HasInboundCidrOverride, !Ref InboundCidrOverride, "0.0.0.0/0"]
         - IpProtocol: tcp
+          FromPort: !FindInMap [ServicesMeta, JanusTurnExternal, Port]
+          ToPort: !FindInMap [ServicesMeta, JanusTurnExternal, Port]
+          CidrIp: !If [HasInboundCidrOverride, !Ref InboundCidrOverride, "0.0.0.0/0"]
+        - IpProtocol: udp
           FromPort: !FindInMap [ServicesMeta, JanusTurnExternal, Port]
           ToPort: !FindInMap [ServicesMeta, JanusTurnExternal, Port]
           CidrIp: !If [HasInboundCidrOverride, !Ref InboundCidrOverride, "0.0.0.0/0"]
@@ -2516,6 +2524,16 @@ Resources:
         - IpProtocol: tcp
           FromPort: 587
           ToPort: 587
+          CidrIp: 0.0.0.0/0
+        # Outbound SMTP 25
+        - IpProtocol: tcp
+          FromPort: 25
+          ToPort: 25
+          CidrIp: 0.0.0.0/0
+        # Outbound SMTP Sendgrid 2525
+        - IpProtocol: tcp
+          FromPort: 2525
+          ToPort: 2525
           CidrIp: 0.0.0.0/0
         # Outbound NTP
         - IpProtocol: udp

--- a/cloudformation/stack.yaml
+++ b/cloudformation/stack.yaml
@@ -365,10 +365,14 @@ Mappings:
       Port: 443
     RetInternal:
       Port: 4000
+    RetTurnExternal:
+      Port: 5349
     JanusInternal:
       Port: 8443
     JanusExternal:
       Port: 80
+    JanusTurnExternal:
+      Port: 443
     JanusAdmin:
       Port: 7000
     JanusWebRTCFrom:
@@ -1800,6 +1804,7 @@ Resources:
         - reticulum.default
         - janus-gateway.default
         - postgrest.default
+        - coturn.default
         - certbot.default
         - ita.default
         - speelycaptor.default
@@ -2473,8 +2478,16 @@ Resources:
           ToPort: !FindInMap [ServicesMeta, RetExternal, Port]
           CidrIp: !If [HasInboundCidrOverride, !Ref InboundCidrOverride, "0.0.0.0/0"]
         - IpProtocol: tcp
+          FromPort: !FindInMap [ServicesMeta, RetTurnExternal, Port]
+          ToPort: !FindInMap [ServicesMeta, RetTurnExternal, Port]
+          CidrIp: !If [HasInboundCidrOverride, !Ref InboundCidrOverride, "0.0.0.0/0"]
+        - IpProtocol: tcp
           FromPort: !FindInMap [ServicesMeta, JanusExternal, Port]
           ToPort: !FindInMap [ServicesMeta, JanusExternal, Port]
+          CidrIp: !If [HasInboundCidrOverride, !Ref InboundCidrOverride, "0.0.0.0/0"]
+        - IpProtocol: tcp
+          FromPort: !FindInMap [ServicesMeta, JanusTurnExternal, Port]
+          ToPort: !FindInMap [ServicesMeta, JanusTurnExternal, Port]
           CidrIp: !If [HasInboundCidrOverride, !Ref InboundCidrOverride, "0.0.0.0/0"]
         - IpProtocol: udp
           FromPort: !FindInMap [ServicesMeta, JanusWebRTCFrom, Port]
@@ -3551,11 +3564,24 @@ Resources:
 
   AppPostgrestDbSecret:
     Type: Custom::GenerateSecret
+    DependsOn: AppCoturnDbSecret
     DeletionPolicy: Retain
     Properties:
       Description: 'PostgREST admin db password'
       ServiceToken: !GetAtt KeymasterApplication.Outputs.GenerateSecretFunctionArn
       Name: postgrest-db-secret
+      Region: !Ref "AWS::Region"
+      StackName: !Ref "AWS::StackName"
+      CopyFromStackName: !If [IsRestore, !Ref RestoreStackName, !Ref "AWS::NoValue"]
+      CopyFromStackRegion: !If [IsRestore, !Ref "AWS::Region", !Ref "AWS::NoValue"]
+
+  AppCoturnDbSecret:
+    Type: Custom::GenerateSecret
+    DeletionPolicy: Retain
+    Properties:
+      Description: 'PostgREST admin db password'
+      ServiceToken: !GetAtt KeymasterApplication.Outputs.GenerateSecretFunctionArn
+      Name: coturn-db-secret
       Region: !Ref "AWS::Region"
       StackName: !Ref "AWS::StackName"
       CopyFromStackName: !If [IsRestore, !Ref RestoreStackName, !Ref "AWS::NoValue"]
@@ -3787,13 +3813,13 @@ Outputs:
     Description: Reticulum Bot Access Key Secret [reticulum/ret/bot_access_key!read-keymaster-secret]
     Value: reticulum-bot-access-key
 
-  AppDbUsername:
-    Description: App DB Username [reticulum/db/username,ita/db/username]
-    Value: postgres
-
   AppDbSecret:
     Description: App DB Secret [ita/db/password!read-aws-secret]
     Value: !Ref AppDbSecret
+
+  AppCoturnDbSecret:
+    Description: App Coturn DB Secret [reticulum/db/coturn_password!read-keymaster-secret]
+    Value: coturn-db-secret
 
   AppPostgrestDbSecret:
     Description: App PostgREST DB Secret [reticulum/db/postgrest_password!read-keymaster-secret]
@@ -3810,6 +3836,10 @@ Outputs:
   PostgrestDbURI:
     Description: Postgrest DB URI [postgrest/db/uri!inject-keymaster-secret]
     Value: !Sub "postgres://postgrest_authenticator:{postgrest-db-secret}@${AppDb.Endpoint.Address}/polycosm_production"
+
+  CoturnDbURI:
+    Description: Coturn DB URI [coturn/general/psql_userdb!inject-keymaster-secret]
+    Value: !Sub "postgresql://coturn:{coturn-db-secret}@${AppDb.Endpoint.Address}/polycosm_production"
 
   PgbouncerDb:
     Description: Pgbouncer DB Info [pgbouncer/pgbouncer/db!inject-aws-secret]

--- a/cloudformation/stack.yaml
+++ b/cloudformation/stack.yaml
@@ -3833,10 +3833,6 @@ Outputs:
     Description: Postgrest DB URI [postgrest/db/uri!inject-keymaster-secret]
     Value: !Sub "postgres://postgrest_authenticator:{postgrest-db-secret}@${AppDb.Endpoint.Address}/polycosm_production"
 
-  CoturnDbURI:
-    Description: Coturn DB URI [coturn/general/psql_userdb!inject-keymaster-secret]
-    Value: !Sub "postgresql://coturn:{coturn-db-secret}@${AppDb.Endpoint.Address}/polycosm_production"
-
   PgbouncerDb:
     Description: Pgbouncer DB Info [pgbouncer/pgbouncer/db!inject-aws-secret]
     Value: !Sub "polycosm_production = host=${AppDb.Endpoint.Address} dbname=polycosm_production user=postgres password={${AppDbSecret}} pool_mode=transaction\npolycosm_locking = host=${AppDb.Endpoint.Address} dbname=polycosm_production user=postgres password={${AppDbSecret}} pool_mode=session"

--- a/cloudformation/stack.yaml
+++ b/cloudformation/stack.yaml
@@ -3722,7 +3722,7 @@ Outputs:
     Value: !If [ HasALB, !GetAtt AppALB.DNSName, !GetAtt AppCloudfrontDistribution.DomainName ]
 
   DomainName:
-    Description: Primary hub domain name [reticulum/phx/url_host,reticulum/phx/static_url_host,hubs/general/reticulum_server,spoke/general/reticulum_server,spoke/general/hubs_server]
+    Description: Primary hub domain name [reticulum/phx/url_host,reticulum/phx/static_url_host,hubs/general/reticulum_server,spoke/general/reticulum_server,spoke/general/hubs_server,reticulum/turn/realm]
     Value: !Ref DomainName
 
   CorsOrigins:

--- a/cloudformation/stack.yaml
+++ b/cloudformation/stack.yaml
@@ -3722,7 +3722,7 @@ Outputs:
     Value: !If [ HasALB, !GetAtt AppALB.DNSName, !GetAtt AppCloudfrontDistribution.DomainName ]
 
   DomainName:
-    Description: Primary hub domain name [reticulum/phx/url_host,reticulum/phx/static_url_host,hubs/general/reticulum_server,spoke/general/reticulum_server,spoke/general/hubs_server,reticulum/turn/realm]
+    Description: Primary hub domain name [reticulum/phx/url_host,reticulum/phx/static_url_host,hubs/general/reticulum_server,spoke/general/reticulum_server,spoke/general/hubs_server,reticulum/turn/realm,coturn/general/realm]
     Value: !Ref DomainName
 
   CorsOrigins:

--- a/cloudformation/stack.yaml
+++ b/cloudformation/stack.yaml
@@ -2598,6 +2598,15 @@ Resources:
       FromPort: !FindInMap [ServicesMeta, PostgreSQL, Port]
       DestinationSecurityGroupId: !Ref AppDbSecurityGroup
 
+  StreamDbEgress:
+    Type: AWS::EC2::SecurityGroupEgress
+    Properties:
+      GroupId: !Ref StreamSecurityGroup
+      IpProtocol: tcp
+      ToPort: !FindInMap [ServicesMeta, PostgreSQL, Port]
+      FromPort: !FindInMap [ServicesMeta, PostgreSQL, Port]
+      DestinationSecurityGroupId: !Ref AppDbSecurityGroup
+
   AppFullSelfEgress:
     Type: AWS::EC2::SecurityGroupEgress
     Properties:
@@ -3465,6 +3474,10 @@ Resources:
           ToPort: !FindInMap [ServicesMeta, PostgreSQL, Port]
           FromPort: !FindInMap [ServicesMeta, PostgreSQL, Port]
           SourceSecurityGroupId: !Ref AppSecurityGroup
+        - IpProtocol: tcp
+          ToPort: !FindInMap [ServicesMeta, PostgreSQL, Port]
+          FromPort: !FindInMap [ServicesMeta, PostgreSQL, Port]
+          SourceSecurityGroupId: !Ref StreamSecurityGroup
 
   DiskKmsKey:
     Type: AWS::KMS::Key
@@ -3564,24 +3577,11 @@ Resources:
 
   AppPostgrestDbSecret:
     Type: Custom::GenerateSecret
-    DependsOn: AppCoturnDbSecret
     DeletionPolicy: Retain
     Properties:
       Description: 'PostgREST admin db password'
       ServiceToken: !GetAtt KeymasterApplication.Outputs.GenerateSecretFunctionArn
       Name: postgrest-db-secret
-      Region: !Ref "AWS::Region"
-      StackName: !Ref "AWS::StackName"
-      CopyFromStackName: !If [IsRestore, !Ref RestoreStackName, !Ref "AWS::NoValue"]
-      CopyFromStackRegion: !If [IsRestore, !Ref "AWS::Region", !Ref "AWS::NoValue"]
-
-  AppCoturnDbSecret:
-    Type: Custom::GenerateSecret
-    DeletionPolicy: Retain
-    Properties:
-      Description: 'PostgREST admin db password'
-      ServiceToken: !GetAtt KeymasterApplication.Outputs.GenerateSecretFunctionArn
-      Name: coturn-db-secret
       Region: !Ref "AWS::Region"
       StackName: !Ref "AWS::StackName"
       CopyFromStackName: !If [IsRestore, !Ref RestoreStackName, !Ref "AWS::NoValue"]
@@ -3816,10 +3816,6 @@ Outputs:
   AppDbSecret:
     Description: App DB Secret [ita/db/password!read-aws-secret]
     Value: !Ref AppDbSecret
-
-  AppCoturnDbSecret:
-    Description: App Coturn DB Secret [reticulum/db/coturn_password!read-keymaster-secret]
-    Value: coturn-db-secret
 
   AppPostgrestDbSecret:
     Description: App PostgREST DB Secret [reticulum/db/postgrest_password!read-keymaster-secret]

--- a/cloudformation/stack.yaml
+++ b/cloudformation/stack.yaml
@@ -3149,6 +3149,14 @@ Resources:
           FromPort: !FindInMap [ServicesMeta, JanusExternal, Port]
           ToPort: !FindInMap [ServicesMeta, JanusExternal, Port]
           CidrIp: !If [HasInboundCidrOverride, !Ref InboundCidrOverride, "0.0.0.0/0"]
+        - IpProtocol: tcp
+          FromPort: !FindInMap [ServicesMeta, JanusTurnExternal, Port]
+          ToPort: !FindInMap [ServicesMeta, JanusTurnExternal, Port]
+          CidrIp: !If [HasInboundCidrOverride, !Ref InboundCidrOverride, "0.0.0.0/0"]
+        - IpProtocol: udp
+          FromPort: !FindInMap [ServicesMeta, JanusTurnExternal, Port]
+          ToPort: !FindInMap [ServicesMeta, JanusTurnExternal, Port]
+          CidrIp: !If [HasInboundCidrOverride, !Ref InboundCidrOverride, "0.0.0.0/0"]
         - IpProtocol: udp
           FromPort: !FindInMap [ServicesMeta, JanusWebRTCFrom, Port]
           ToPort: !FindInMap [ServicesMeta, JanusWebRTCTo, Port]

--- a/plans/coturn/habitat/config/turnserver.conf
+++ b/plans/coturn/habitat/config/turnserver.conf
@@ -869,3 +869,15 @@ no-tlsv1_1={{ cfg.general.no_tlsv1_1 }}
 {{ #if cfg.general.no_tlsv1_2 }}
 no-tlsv1_2={{ cfg.general.no_tlsv1_2 }}
 {{ /if }}
+
+{{ #if cfg.general.no_auth_pings }}
+no-auth-pings={{ cfg.general.no_auth_pings }}
+{{ /if }}
+
+{{ #if cfg.general.no_dynamic_ip_list }}
+no-dynamic-ip-list={{ cfg.general.no_dynamic_ip_list }}
+{{ /if }}
+
+{{ #if cfg.general.no_dynamic_realms }}
+no-dynamic-realms={{ cfg.general.no_dynamic_realms }}
+{{ /if }}

--- a/plans/coturn/habitat/config/turnserver.conf
+++ b/plans/coturn/habitat/config/turnserver.conf
@@ -320,6 +320,10 @@ userdb={{ pkg.svc_var_path }}/db/turndb
 psql-userdb="{{ cfg.general.psql_userdb }}"
 {{ /if }}
 
+{{ #if cfg.general.psql_schema }}
+psql-schema="{{ cfg.general.psql_schema }}"
+{{ /if }}
+
 # MySQL database connection string in the case that you are using MySQL
 # as the user database.
 # This database can be used for the long-term credential mechanism

--- a/plans/coturn/habitat/config/turnserver.conf
+++ b/plans/coturn/habitat/config/turnserver.conf
@@ -715,7 +715,7 @@ max-allocate-timeout={{ cfg.general.max_allocate_timeout }}
 #
 # See: https://www.rtcsec.com/2020/04/01-slack-webrtc-turn-compromise/
 no-multicast-peers
-denied-peer-ip=0.0.0.1-0.255.255.255
+denied-peer-ip=0.0.0.0-0.255.255.255
 denied-peer-ip=10.0.0.0-10.255.255.255
 denied-peer-ip=100.64.0.0-100.127.255.255
 denied-peer-ip=127.0.0.0-127.255.255.255

--- a/plans/coturn/habitat/plan.sh
+++ b/plans/coturn/habitat/plan.sh
@@ -2,9 +2,9 @@ pkg_name=coturn
 pkg_origin=mozillareality
 pkg_maintainer="Mozilla Mixed Reality <mixreality@mozilla.com>"
 
-pkg_version="4.5.1.1"
-pkg_source="https://github.com/coturn/coturn/archive/${pkg_version}.tar.gz"
-pkg_shasum="8eabe4c241ad9a74655d8516c69b1fa3275e020e7f7fca50a6cb822809e7c220"
+pkg_version="4.5.2.0"
+pkg_source="https://github.com/mozillareality/coturn/archive/${pkg_version}.tar.gz"
+pkg_shasum="92ce593c01013b372084f5dfce4f07c1a96870d6cb59e22328a12db45f67b342"
 pkg_license=('COTURN')
 pkg_deps=(
   mozillareality/openssl

--- a/plans/coturn/habitat/plan.sh
+++ b/plans/coturn/habitat/plan.sh
@@ -2,9 +2,9 @@ pkg_name=coturn
 pkg_origin=mozillareality
 pkg_maintainer="Mozilla Mixed Reality <mixreality@mozilla.com>"
 
-pkg_version="4.5.2.0"
+pkg_version="4.5.3.0"
 pkg_source="https://github.com/mozillareality/coturn/archive/${pkg_version}.tar.gz"
-pkg_shasum="92ce593c01013b372084f5dfce4f07c1a96870d6cb59e22328a12db45f67b342"
+pkg_shasum="760e5ad2057ac306b9582c401efa28cc0ad46423f1cd4d4acd7fa4074016039e"
 pkg_license=('COTURN')
 pkg_deps=(
   mozillareality/openssl


### PR DESCRIPTION
Adds TURN (DTLS + TCP/TLS) for Hubs Cloud, among other improvements, for the AWS Marketplace listing update in 04/2020.

- Add coturn support
- Enable SMTP access over 25 + 2525 in addition to 587
- Fix issues with servers not working when rebooted
- Fix bug with email not working if email domain prefix left blank