### PR TITLE
Fix domain matching in Route53DependencyLambda

### DIFF
--- a/cloudformation/stack.yaml
+++ b/cloudformation/stack.yaml
@@ -695,7 +695,7 @@ Resources:
                 if (properties.Id) {
                   return zone.Id === "/hostedzone/" + properties.Id;
                 } else {
-                  var apexParts = properties.Domain.split(".");
+                  var apexParts = properties.Domain.split(".").filter(Boolean);
                   var apex = apexParts.slice(1, apexParts.length).join(".");
                   return zone.Name === apex + ".";
                 }

--- a/cloudformation/stack.yaml
+++ b/cloudformation/stack.yaml
@@ -695,9 +695,9 @@ Resources:
                 if (properties.Id) {
                   return zone.Id === "/hostedzone/" + properties.Id;
                 } else {
-                  var tldParts = properties.Domain.split(".");
-                  var tld = tldParts[tldParts.length - 2] + "." + tldParts[tldParts.length - 1];
-                  return zone.Name === tld + ".";
+                  var apexParts = properties.Domain.split(".");
+                  var apex = apexParts.slice(1, apexParts.length).join(".");
+                  return zone.Name === apex + ".";
                 }
               });
               if (matching.length != 1)


### PR DESCRIPTION
Hi, I faced a problem while creating a stack.

my environment is, such like,
- CFn param DomainName: hubs.my.domain.com
- Route53 zone: my.domain.com

and I got the following error.
```
2020-04-16 17:39:22 UTC+0900	ExternalZoneInfo	
CREATE_FAILED	Failed to create resource. undefined See details in CloudWatch Log: 2020/04/16/[$LATEST]bf8dde3ec87246b8b899fdc0263ed32f

undefined See details in CloudWatch Log
Route53DependencyLambda
```
commit 6f51c92 fixes this.

The commit 5b6d9b5 is for another problem, I think, that `DomainName` is validated by pattern 
https://github.com/mozilla/hubs-ops/blob/ef92c35f876bc8afd963d199f799d45335c1a052/cloudformation/stack.yaml#L150 which allows a period at the end, but it may cause a matching failure.
```
> 'hubs.my.domain.com.'.split('.')
[ 'hubs', 'my', 'domain', 'com', '' ]
```