### PR TITLE
fix(CF Stack): Route53DependencyLambda zone matching logic

### DIFF
--- a/cloudformation/stack.yaml
+++ b/cloudformation/stack.yaml
@@ -695,9 +695,7 @@ Resources:
                 if (properties.Id) {
                   return zone.Id === "/hostedzone/" + properties.Id;
                 } else {
-                  var tldParts = properties.Domain.split(".");
-                  var tld = tldParts[tldParts.length - 2] + "." + tldParts[tldParts.length - 1];
-                  return zone.Name === tld + ".";
+                  return zone.Name === properties.Domain + '.';
                 }
               });
               if (matching.length != 1)


### PR DESCRIPTION
**This PR adjusts the matching logic present in the `Route53DependencyLambda` section of the CloudFormation Stack.**

We found that by excluding the `properties.Domain.split(".")` logic and instead simply comparing `zone.Name` with `properties.Domain + '.'` we were able to spin up a new instance of Hubs using a sub-domain who's root domain was not hosted on Route53. This means that both Domain Recipe 1 and 2 are able to be used on any given domain name as long as that domain has a Route53 Hosted Zone. It might, we haven't tested it, also mean that the `.co.uk` bug should also be fixed.

IE:
- `hubs.mydomain.com` can have `NS` records pointing to a Route53 Hosted Zone
- `mydomain.com` can be hosted with another DNS provider
- `hubs.mydomain.com` can still be used as the external hosted zone when creating a Hubs instance

Previously:
- `hubs.mydomain.com` **and** `mydomain.com` both had to be hosted via Route53