### PR TITLE
Add Host header to Hubs Cloud CloudFront behavior to fix upload requests

### DIFF
--- a/cloudformation/stack.yaml
+++ b/cloudformation/stack.yaml
@@ -3127,7 +3127,7 @@ Resources:
             TargetOriginId: !Sub "${AWS::StackName}-app"
             ForwardedValues:
               QueryString: true
-              Headers: ["Origin", "Content-Type", "Authorization", "Access-Control-Request-Method", "Access-Control-Request-Headers", "Accept", "Range"]
+              Headers: ["Origin", "Content-Type", "Host", "Authorization", "Access-Control-Request-Method", "Access-Control-Request-Headers", "Accept", "Range"]
               Cookies:
                 Forward: none
             ViewerProtocolPolicy: https-only


### PR DESCRIPTION
In https://github.com/mozilla/reticulum/pull/508 we added a restriction that prevents uploads being served from the primary domain. That change worked on HMC, but not on the current Hubs Cloud release candidate, since the CloudFront configuration in our CloudFormation stack is not configured to pass the Host header along to the server. As a result, uploaded files, including scenes and avatars fail to load.
This PR adds the required header to fix this issue.