### PR TITLE
Update cors proxy to match the one in production

### DIFF
--- a/workers/cors-proxy-internal.js
+++ b/workers/cors-proxy-internal.js
@@ -1,52 +1,23 @@
 const ALLOWED_ORIGINS = ["https://hubs.local:8080", "https://hubs.local:9090", "https://hubs.local:4000", "https://dev.reticulum.io", "https://smoke-dev.reticulum.io", "https://hubs.mozilla.com", "https://smoke-hubs.mozilla.com", "https://photomnemonic-utils.reticulum.io"];
-const PROXY_HOST = "https://hubs-proxy.com"
-const STORAGE_HOST = "https://hubs.mozilla.com";
-const ASSETS_HOST = "https://assets-prod.reticulum.io";
-  
-let cache = caches.default;
+const PROXY_HOST = "https://hubs-proxy.com";
 
 addEventListener("fetch", e => {
   const request = e.request;
   const origin = request.headers.get("Origin");
   const proxyUrl = new URL(PROXY_HOST);
-  // eslint-disable-next-line no-useless-escape
-
-  const isCorsProxy = request.url.indexOf("https://cors-proxy.") === 0;
-  const targetPath = request.url.replace(/^https:\/\/cors-proxy\./, "https://").substring(PROXY_HOST.length + 1);
-  let useCache = false;
-  let targetUrl;
-
-  if (targetPath.indexOf("files/") === 0) {
-    useCache = true;
-    targetUrl = `${STORAGE_HOST}/${targetPath}`;
-  } else if (targetPath.indexOf("hubs/") === 0 || targetPath.indexOf("spoke/") === 0 || targetPath.indexOf("admin/") === 0) {
-    useCache = true;
-    targetUrl = `${ASSETS_HOST}/${targetPath}`;
-  } else {
-    if (!isCorsProxy) {
-      // Do not allow cors proxying from main domain, always require cors-proxy. subdomain to ensure CSP stays sane.
-      return;
-    }
-    targetUrl = targetPath.replace(/^http(s?):\/([^/])/, "http$1://$2");
-
-    if (!targetUrl.startsWith("http://") && !targetUrl.startsWith("https://")) {
-      targetUrl = proxyUrl.protocol + "//" + targetUrl;
-    }
+  let targetUrl = request.url.substring(PROXY_HOST.length + 1).replace(/^http(s?):\/([^/])/, "http$1://$2");
+  
+  if (!targetUrl.startsWith("http://") && !targetUrl.startsWith("https://")) {
+    targetUrl = proxyUrl.protocol + "//" + targetUrl;
   }
+  
   const requestHeaders = new Headers(request.headers);
   requestHeaders.delete("Origin"); // Some domains disallow access from improper Origins
 
   e.respondWith((async () => {
-    let cacheReq;
-
-    if (useCache) {
-      cacheReq = new Request(targetUrl, { headers: requestHeaders, method: request.method, redirect: "manual" });
-      const res = await cache.match(cacheReq, {});
-      if (res) return res;
-    }
-
-    const res = await fetch(targetUrl, { headers: requestHeaders, method: request.method, redirect: "manual", referrer: request.referrer, referrerPolicy: request.referrerPolicy });      
+    const res = await fetch(targetUrl, { headers: requestHeaders, method: request.method, redirect: "manual", referrer: request.referrer, referrerPolicy: request.referrerPolicy });
     const responseHeaders = new Headers(res.headers);
+
     const redirectLocation = responseHeaders.get("Location") || responseHeaders.get("location");
 
     if(redirectLocation) {
@@ -67,14 +38,7 @@ addEventListener("fetch", e => {
 
     responseHeaders.set("Vary", "Origin");
     responseHeaders.set('X-Content-Type-Options', "nosniff");
-    let body = res.body;
 
-    if (useCache) {
-      const [body1, body2] = res.body.tee();
-      body = body2;
-      await cache.put(cacheReq, new Response(body1, { status: res.status, statusText: res.statusText, headers: responseHeaders }));
-    }
-
-    return new Response(body, { status: res.status, statusText: res.statusText, headers: responseHeaders });  
+    return new Response(res.body, { status: res.status, statusText: res.statusText, headers: responseHeaders });
   })());
 });


### PR DESCRIPTION
The code for the internal cors proxy here didn't actually match the code that we currently have deployed to production.

I'm not sure why the code differs. It seems the code in the repo had additional functionality to cache files and assets from reticulum and S3, presumably in an attempt to save on bandwidth or load, but we either never deployed this version, or we reverted it at some point. In either case, it's best if the code in the repo matches what we actually have in production.