### PR TITLE
Forward user-agent header in uploads cloudfront distribution

### DIFF
--- a/terraform/modules/ret/main.tf
+++ b/terraform/modules/ret/main.tf
@@ -477,7 +477,7 @@ resource "aws_cloudfront_distribution" "ret-uploads" {
 
     forwarded_values {
       query_string = true
-      headers = ["Origin", "Content-Type", "Authorization", "Range", "Access-Control-Request-Headers", "Access-Control-Request-Method"]
+      headers = ["Origin", "Content-Type", "Authorization", "Range", "Access-Control-Request-Headers", "Access-Control-Request-Method", "User-Agent"]
       cookies { forward = "none" }
     }
 


### PR DESCRIPTION
Related to https://github.com/mozilla/reticulum/pull/541

We need to forward the user-agent header through the uploads distribution in order to apply CSP headers correctly.