### PR TITLE
Update speelycaptor version to use a version with the latest code

### DIFF
--- a/cloudformation/stack.yaml
+++ b/cloudformation/stack.yaml
@@ -2108,7 +2108,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:558986605633:applications/speelycaptor
-        SemanticVersion: 0.0.1
+        SemanticVersion: 0.1.3
       Parameters:
         SpeelycaptorRoleArn: !GetAtt SpeelycaptorRole.Arn
         SpeelycaptorScratchBucketId: !Ref SpeelycaptorScratchBucket


### PR DESCRIPTION
It seems v0.0.1 of speelycaptor, which we deployed during the last set of lambda updates, actually contained old code that broke video uploads. We deployed v0.1.3 to fix this, using the latest code from https://github.com/mozilla/speelycaptor