### PR TITLE
Updated photomnemonic version to 0.3.0

### DIFF
--- a/cloudformation/stack.yaml
+++ b/cloudformation/stack.yaml
@@ -2119,7 +2119,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:558986605633:applications/photomnemonic
-        SemanticVersion: 0.0.1
+        SemanticVersion: 0.3.0
       Parameters:
         PhotomnemonicRoleArn: !GetAtt PhotomnemonicRole.Arn
   NearsparkApiGatewayRestApi:


### PR DESCRIPTION
This fixes website screenshots that were returning 500s because the node runtime version wasn't updated to the latest on Hubs Cloud.