### PR TITLE
Add whats new token to reticulum ansible template

### DIFF
--- a/ansible/roles/ret/templates/reticulum.toml.j2
+++ b/ansible/roles/ret/templates/reticulum.toml.j2
@@ -106,6 +106,11 @@ access_token = "{{ twitter_client_access_token }}"
 access_token_secret = "{{ twitter_client_access_token_secret }}"
 {% endif %}
 
+[whats_new]
+{% if whats_new_token is defined %}
+token = "{{ whats_new_token }}"
+{% endif %}
+
 [resolver]
 {% if giphy_api_key is defined %}
 giphy_api_key = "{{ giphy_api_key }}"


### PR DESCRIPTION
Adds a section and token field for the new whats-new API. 
Goes with https://github.com/mozilla/reticulum/pull/559