### PR TITLE
Fix zone matching logic in Route53DependencyLambda

### DIFF
--- a/cloudformation/stack.yaml
+++ b/cloudformation/stack.yaml
@@ -696,9 +696,7 @@ Resources:
                 if (properties.Id) {
                   return zone.Id === "/hostedzone/" + properties.Id;
                 } else {
-                  var tldParts = properties.Domain.split(".");
-                  var tld = tldParts[tldParts.length - 2] + "." + tldParts[tldParts.length - 1];
-                  return zone.Name === tld + ".";
+                  return zone.Name === properties.Domain + '.';
                 }
               });
               if (matching.length != 1)


### PR DESCRIPTION
This replays a change from an old PR that never got merged. https://github.com/mozilla/hubs-ops/pull/103

The next steps are 
- [ ] test this Cloudformation template, 
- [ ] upload it to amazon, 
- [ ] wait for approval, 
- [ ] ship to the marketplace.


