### PR TITLE
Pin GitHub Actions to specific commit SHAs for supply chain security

### DIFF
--- a/.github/workflows/HcPkgPreReleaseGitops.yaml
+++ b/.github/workflows/HcPkgPreReleaseGitops.yaml
@@ -20,7 +20,7 @@ jobs:
  launch:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
         with:
           fetch-depth: 0
       - run: |

--- a/.github/workflows/turkeyGitops.yml
+++ b/.github/workflows/turkeyGitops.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           path: "./repo"
       - name: use codePath for multirepo
@@ -73,11 +73,11 @@ jobs:
           mv ./_repo ./repo
           ls ./repo
       - name: docker setup buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
         with:
           install: true
       - name: docker build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: repo/
           file: repo/${{ inputs.dockerfile }}
@@ -89,13 +89,13 @@ jobs:
             CONTENTFUL_TOKEN_b64=$${{ secrets.docker_args-contentful_token_b64 }}
       - name: docker login
         if: ${{ github.repository_owner == 'Hubs-Foundation' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ inputs.DOCKER_HUB_USR }}
           password: ${{ secrets.DOCKER_HUB_PWD }}
       - name: docker push
         if: ${{ github.repository_owner == 'Hubs-Foundation' }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: repo/
           file: repo/${{ inputs.dockerfile }}


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions in workflow files to full-length commit SHAs instead of mutable version tags
- Each pinned reference includes a version comment (e.g. `# v4.3.1`) for readability
- Affected workflows: `HcPkgPreReleaseGitops.yaml`, `turkeyGitops.yml`

## Motivation

Using mutable version tags (e.g. `@v4`) for GitHub Actions is a supply chain security risk, as tags can be moved to point to arbitrary commits. Pinning to commit SHAs ensures workflows always run the exact, audited version of each action.

## Changes

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `@v2` | `@ee0669bd...` (v2.7.0) |
| `actions/checkout` | `@v4` | `@34e11487...` (v4.3.1) |
| `docker/setup-buildx-action` | `@v3` | `@8d2750c6...` (v3.12.0) |
| `docker/build-push-action` | `@v6` | `@10e90e36...` (v6.19.2) |
| `docker/login-action` | `@v3` | `@c94ce9fb...` (v3.7.0) |