### PR TITLE
Apply Zizmor fixes to increase HcPkgPreReleaseGitops workflow security

### DIFF
--- a/.github/workflows/HcPkgPreReleaseGitops.yaml
+++ b/.github/workflows/HcPkgPreReleaseGitops.yaml
@@ -23,30 +23,35 @@ jobs:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
         with:
           fetch-depth: 0
+          persist-credentials: false
       - run: |
          echo "Prep work"
-         git fetch origin  ${{inputs.releaseTrackingBranch}}
-         git fetch origin  ${{inputs.qatestBranch}}
+         git fetch origin  ${INPUTS_RELEASETRACKINGBRANCH}
+         git fetch origin  ${INPUTS_QATESTBRANCH}
          tag="hc.test.$(date '+%Y-%m-%d')"
          echo "$tag"
          
          echo "Point releaseTrackingBranch to current qa-test"
          git reset HEAD --hard 
-         git checkout ${{inputs.qaTestBranch}}
-         git pull origin ${{inputs.qaTestBranch}}
+         git checkout ${INPUTS_QATESTBRANCH}
+         git pull origin ${INPUTS_QATESTBRANCH}
          sha=$(git rev-parse  HEAD)
-         echo "${{inputs.qaTestBranch}} branch sha: $sha"
-         git checkout ${{inputs.releaseTrackingBranch}}
-         git update-ref 'refs/heads/${{inputs.releaseTrackingBranch}}' $sha 
-         git push origin ${{inputs.releaseTrackingBranch}} -f
+         echo "${INPUTS_QATESTBRANCH} branch sha: $sha"
+         git checkout ${INPUTS_RELEASETRACKINGBRANCH}
+         git update-ref 'refs/heads/${INPUTS_RELEASETRACKINGBRANCH}' $sha 
+         git push origin ${INPUTS_RELEASETRACKINGBRANCH} -f
 
          echo "Point qa-test branch to current master"
          git reset HEAD --hard
-         git checkout ${{inputs.main}} 
+         git checkout ${INPUTS_MAIN} 
          sha=$(git rev-parse  HEAD)
          echo "master branch sha: $sha"
-         git checkout ${{inputs.qatestBranch}}
-         git update-ref  'refs/heads/${{inputs.qatestBranch}}' $sha 
-         git push origin ${{inputs.qatestBranch}} -f 
+         git checkout ${INPUTS_QATESTBRANCH}
+         git update-ref  'refs/heads/${INPUTS_QATESTBRANCH}' $sha 
+         git push origin ${INPUTS_QATESTBRANCH} -f 
          git tag  $tag 
          git push origin $tag
+        env:
+          INPUTS_RELEASETRACKINGBRANCH: ${{inputs.releaseTrackingBranch}}
+          INPUTS_QATESTBRANCH: ${{inputs.qatestBranch}}
+          INPUTS_MAIN: ${{inputs.main}}


### PR DESCRIPTION
## What?
<!-- REQUIRED — Explain what your pull request does -->
Prevents credentials from actions/checkout from persisting, and replaces direct use of the GitHub variables in the shell execution with indirect usage via shell variables.

## Why?
<!-- REQUIRED — Explain why you're opening this pull request, what limitations does it address, etc..  If you're fixing a bug with an open bug report you can just link to the bug report -->
To help minimize the chance of the workflow being hacked.

According to Zizmor, filtering GitHub variables through environment variables prevents code injection via template expansion.  Essentially, this should ensure an attacker can't manipulate data in GitHub to achieve remote code execution when the workflow is run.

## Examples
<!-- OPTIONAL — If applicable, give examples of the changes the user will observe, e.g. screenshots, videos, diagrams, console output, etc., otherwise put "N/A" or remove the section.  Including examples of before the PR and after the PR is encouraged. -->
N/A

## How to test
<!-- REQUIRED — Give the steps required to test your pull request -->

DO NOT TEST THE WORKFLOW ITSELF.  This workflow isn't currently used and running this workflow will overwrite branches.

To verify that all the Zizmor issues have been addressed, run the following command from the repository folder and see that Zizmor reports no issues (that we care about) for the HcPkgPreReleaseGitops workflow.
```
docker run --rm --name zizmor -v .:/usr/repo ghcr.io/zizmorcore/zizmor --fix=all /usr/repo
```

## Documentation of functionality
<!-- REQUIRED — Link to the accompanying documentation pull request or identify where the documentation is located in this pull request.  If no documentation is needed, please specify this here -->
This doesn't change the functionality of the workflow, so no documentation update is needed.

## Known limitations
<!-- OPTIONAL — If there is anything you decided not to do/support in this PR that might otherwise be expected, list them here along with the reason why you didn't do/support them, otherwise put "None" -->
This doesn't limit the permissions.  This workflow isn't currently used and running this workflow will overwrite branches, so there isn't a way to test what permissions it needs and it doesn't really matter at this point in time if it works or not (if we decide to start using the workflow, then we can figure out the permissions then).  Since it is planned to globally restrict permissions for all Hubs Foundation workflows, there shouldn't be any risk to leaving the permissions as is.

This doesn't update any of the external workflow versions. I feel it is out of scope for this PR and can/should be done along with all the others in further PRs when addressing GitHub's required update to use Node 24+.

## Alternative implementations considered
<!-- OPTIONAL — If there are any alternative ways of implementing this change that you thought of, but decided against, list them here along with why they were discarded, otherwise put "None" -->
None.

## Open questions
<!-- OPTIONAL — If you have any questions, put them here, otherwise put "None" -->
None.

## Additional details or related context
<!-- OPTIONAL — If there are any other details that you think the reviewers should be aware of that you didn't put elsewhere, e.g. links to related issues, pull requests, references you used, notes on weird things, attribution, etc., put them here, otherwise put "None" -->
This workflow is unused, so this update is merely out of an abundance of caution.

This workflow can be called from the [hc-pkgcaller workflow in the Reticulum repository](https://github.com/Hubs-Foundation/reticulum/blob/master/.github/workflows/hc-pkgcaller.yml).

Part of https://github.com/Hubs-Foundation/.github/issues/13