### PR TITLE
Increase turkeyGitops workflow security and tighten permissions

### DIFF
--- a/.github/workflows/turkeyGitops.yml
+++ b/.github/workflows/turkeyGitops.yml
@@ -56,6 +56,8 @@ on:
       docker_args-contentful_token_b64:
         required: false
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -64,14 +66,17 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           path: "./repo"
+          persist-credentials: false
       - name: use codePath for multirepo
         if: ${{ inputs.codePath != ''}}
         run: |
           mkdir ./_repo
-          cp -rf ./repo/${{ inputs.codePath }}/* ./_repo
+          cp -rf ./repo/${INPUTS_CODEPATH}/* ./_repo
           rm -rf ./repo
           mv ./_repo ./repo
           ls ./repo
+        env:
+          INPUTS_CODEPATH: ${{ inputs.codePath }}
       - name: docker setup buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
         with:
@@ -162,20 +167,23 @@ jobs:
     steps:
       - name: "master: pull GITHUB_RUN_NUMBER and tag to ${GITHUB_SHA::7} and dev"
         run: |
-          fromTag=${{ inputs.registry }}/${{ github.workflow }}:${{ github.run_number }}
-          echo ${{ secrets.DOCKER_HUB_PWD }} | sudo docker login --username ${{ inputs.DOCKER_HUB_USR }} --password-stdin
+          fromTag=${INPUTS_REGISTRY}/${GITHUB_WORKFLOW}:${{ github.run_number }}
+          echo ${{ secrets.DOCKER_HUB_PWD }} | sudo docker login --username ${INPUTS_DOCKER_HUB_USR} --password-stdin
           
-          toTag=${{ inputs.registry }}/${{ github.workflow }}:${GITHUB_SHA::7}
+          toTag=${INPUTS_REGISTRY}/${GITHUB_WORKFLOW}:${GITHUB_SHA::7}
           echo "[info] promoting :$fromTag to :$toTag"          
           sudo docker pull $fromTag && sudo docker tag $fromTag $toTag && sudo docker push $toTag
           
-          toTag=${{ inputs.registry }}/${{ github.workflow }}:dev-$GITHUB_RUN_NUMBER
+          toTag=${INPUTS_REGISTRY}/${GITHUB_WORKFLOW}:dev-$GITHUB_RUN_NUMBER
           echo "[info] promoting :$fromTag to :$toTag"          
           sudo docker pull $fromTag && sudo docker tag $fromTag $toTag && sudo docker push $toTag
           
-          toTag=${{ inputs.registry }}/${{ github.workflow }}:dev-latest
+          toTag=${INPUTS_REGISTRY}/${GITHUB_WORKFLOW}:dev-latest
           echo "[info] promoting :$fromTag to :$toTag"          
           sudo docker pull $fromTag && sudo docker tag $fromTag $toTag && sudo docker push $toTag
+        env:
+          INPUTS_REGISTRY: ${{ inputs.registry }}
+          INPUTS_DOCKER_HUB_USR: ${{ inputs.DOCKER_HUB_USR }}
 
   # Google Container Registry isn't currently set up as of 2024-09-08
   # so commenting out tag_dev_gcr for now.
@@ -207,16 +215,19 @@ jobs:
     steps:
       - name: "pull :${{ github.run_number }} and tag to staging"
         run: |
-          fromTag=${{ inputs.registry }}/${{ github.workflow }}:${{ github.run_number }}
-          echo ${{ secrets.DOCKER_HUB_PWD }} | sudo docker login --username ${{ inputs.DOCKER_HUB_USR }} --password-stdin
+          fromTag=${INPUTS_REGISTRY}/${GITHUB_WORKFLOW}:${{ github.run_number }}
+          echo ${{ secrets.DOCKER_HUB_PWD }} | sudo docker login --username ${INPUTS_DOCKER_HUB_USR} --password-stdin
           
-          toTag=${{ inputs.registry }}/${{ github.workflow }}:beta-$GITHUB_RUN_NUMBER
+          toTag=${INPUTS_REGISTRY}/${GITHUB_WORKFLOW}:beta-$GITHUB_RUN_NUMBER
           echo "[info] promoting :$fromTag to :$toTag"
           sudo docker pull $fromTag && sudo docker tag $fromTag $toTag && sudo docker push $toTag                  
 
-          toTag=${{ inputs.registry }}/${{ github.workflow }}:beta-latest
+          toTag=${INPUTS_REGISTRY}/${GITHUB_WORKFLOW}:beta-latest
           echo "[info] promoting :$fromTag to :$toTag"
           sudo docker pull $fromTag && sudo docker tag $fromTag $toTag && sudo docker push $toTag  
+        env:
+          INPUTS_REGISTRY: ${{ inputs.registry }}
+          INPUTS_DOCKER_HUB_USR: ${{ inputs.DOCKER_HUB_USR }}
 
   # Google Container Registry isn't currently set up as of 2024-09-08
   # so commenting out tag_beta_gcr for now.
@@ -248,16 +259,19 @@ jobs:
     steps:
       - name: promote artifact to prod
         run: |
-          fromTag=${{ inputs.registry }}/${{ github.workflow }}:${{ github.run_number }}
-          echo ${{ secrets.DOCKER_HUB_PWD }} | sudo docker login --username ${{ inputs.DOCKER_HUB_USR }} --password-stdin
+          fromTag=${INPUTS_REGISTRY}/${GITHUB_WORKFLOW}:${{ github.run_number }}
+          echo ${{ secrets.DOCKER_HUB_PWD }} | sudo docker login --username ${INPUTS_DOCKER_HUB_USR} --password-stdin
           
-          toTag=${{ inputs.registry }}/${{ github.workflow }}:stable-$GITHUB_RUN_NUMBER
+          toTag=${INPUTS_REGISTRY}/${GITHUB_WORKFLOW}:stable-$GITHUB_RUN_NUMBER
           echo "promoting :$fromTag to :$toTag"          
           sudo docker pull $fromTag && sudo docker tag $fromTag $toTag && sudo docker push $toTag
           
-          toTag=${{ inputs.registry }}/${{ github.workflow }}:stable-latest
+          toTag=${INPUTS_REGISTRY}/${GITHUB_WORKFLOW}:stable-latest
           echo "promoting :$fromTag to :$toTag"
           sudo docker pull $fromTag && sudo docker tag $fromTag $toTag && sudo docker push $toTag
+        env:
+          INPUTS_REGISTRY: ${{ inputs.registry }}
+          INPUTS_DOCKER_HUB_USR: ${{ inputs.DOCKER_HUB_USR }}
 
 
   # Google Container Registry isn't currently set up as of 2024-09-08


### PR DESCRIPTION
## What?
<!-- REQUIRED — Explain what your pull request does -->
Sets permissions to none, prevents credentials from actions/checkout from persisting, and replaces direct use of the GitHub variables in the shell execution with indirect usage via shell variables.

## Why?
<!-- REQUIRED — Explain why you're opening this pull request, what limitations does it address, etc..  If you're fixing a bug with an open bug report you can just link to the bug report -->
To help minimize the chance of the workflow being hacked, and in preparation to globally restrict permissions for all Hubs Foundation workflows.

According to Zizmor, filtering GitHub variables through environment variables prevents code injection via template expansion.  Essentially, this should ensure an attacker can't manipulate data in GitHub to achieve remote code execution when the workflow is run.

## Examples
<!-- OPTIONAL — If applicable, give examples of the changes the user will observe, e.g. screenshots, videos, diagrams, console output, etc., otherwise put "N/A" or remove the section.  Including examples of before the PR and after the PR is encouraged. -->
N/A

## How to test
<!-- REQUIRED — Give the steps required to test your pull request -->

It's not practical to test the whole workflow (due to many things being hard-coded to the Hubs Foundation and to stuff being merged into the default branch), but here are some instructions to test the basics.

1. Push the updated workflow to a branch on your fork of hubs-ops.
2. Make a new branch on one of the repos that calls this workflow (e.g. Spoke), modify the calling workflow to call the workflow from the branch on your fork of hubs-ops, and push this to your fork of the calling workflow's repository.
3. Run the calling workflow.
4. See that everything works as normal.

To verify that all the Zizmor issues have been addressed, run the following command from the repository folder (for both this repo and the one for the calling workflow) and see that Zizmor reports no issues (that we care about) for the turkeyGitops workflow or its caller.
```
docker run --rm --name zizmor -v .:/usr/repo ghcr.io/zizmorcore/zizmor --fix=all /usr/repo
```

## Documentation of functionality
<!-- REQUIRED — Link to the accompanying documentation pull request or identify where the documentation is located in this pull request.  If no documentation is needed, please specify this here -->
This doesn't change the functionality of the workflow, so no documentation update is needed.

## Known limitations
<!-- OPTIONAL — If there is anything you decided not to do/support in this PR that might otherwise be expected, list them here along with the reason why you didn't do/support them, otherwise put "None" -->
This doesn't update any of the external workflow versions. I feel it is out of scope for this PR and can/should be done along with all the others in further PRs when addressing GitHub's required update to use Node 24+.

Only the build step of the workflow has actually been tested, the rest will have to be tested after this has been merged (the rest are similar enough to each other that just testing the `tag_dev` should be enough, but we won't know for sure until a stable release has been made for one of the CE services we build).

## Alternative implementations considered
<!-- OPTIONAL — If there are any alternative ways of implementing this change that you thought of, but decided against, list them here along with why they were discarded, otherwise put "None" -->
None.

## Open questions
<!-- OPTIONAL — If you have any questions, put them here, otherwise put "None" -->
None.

## Additional details or related context
<!-- OPTIONAL — If there are any other details that you think the reviewers should be aware of that you didn't put elsewhere, e.g. links to related issues, pull requests, references you used, notes on weird things, attribution, etc., put them here, otherwise put "None" -->
These security improvements were advised by the Zizmor tool and `GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 #v1 Beta 9`

Part of https://github.com/Hubs-Foundation/.github/issues/13
